### PR TITLE
refactor test suite execution to reduce duplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,4 @@ packages/*
 .vagrant/*
 
 .env
-examples/*
-!examples/*.nim
-tests/*
-!tests/*.nim
+

--- a/nimcrypto.nimble
+++ b/nimcrypto.nimble
@@ -13,7 +13,7 @@ requires "nim > 0.18.0"
 # Tests
 
 task tests, "Runs the test suite":
-  for tfile in @[
+  let testFiles = @[
       "testkeccak",
       "testsha2",
       "testripemd",
@@ -26,29 +26,33 @@ task tests, "Runs the test suite":
       "testsysrand",
       "testkdf",
       "testapi",
-    ]:
-    for cmd in @[
-        "nim c -f -r tests/" & tfile,
-        "nim c -f -d:release -r tests/" & tfile,
-        "nim c -f -d:release --threads:on -r tests/" & tfile,
-      ]:
-      echo "\n" & cmd
-      exec cmd
-      rmFile("tests/" & tfile.toExe())
-
-  for efile in @[
+    ]
+  let testCommands = @[
+      "nim c -f -r tests/",
+      "nim c -f -d:release -r tests/",
+      "nim c -f -d:release --threads:on -r tests/",
+    ]
+  let exampleFiles = @[
       "ecb",
       "cbc",
       "ofb",
       "cfb",
       "ctr",
       "gcm",
-    ]:
-    for cmd in @[
-        "nim c -f -r examples/" & efile,
-        "nim c -f -r --threads:on examples/" & efile,
-      ]:
-      echo "\n" & cmd
-      exec cmd
+    ]
+  let exampleCommands = @[
+      "nim c -f -r examples/",
+      "nim c -f -r --threads:on examples/",
+    ]
+
+  for tfile in testFiles:
+    for cmd in testCommands:
+      echo "\n" & cmd & tfile
+      exec cmd & tfile
+      rmFile("tests/" & tfile.toExe())
+  for efile in exampleFiles:
+    for cmd in exampleCommands:
+      echo "\n" & cmd & efile
+      exec cmd & efile
       rmFile("examples/" & efile.toExe())
 

--- a/nimcrypto.nimble
+++ b/nimcrypto.nimble
@@ -13,55 +13,42 @@ requires "nim > 0.18.0"
 # Tests
 
 task tests, "Runs the test suite":
-  exec "nim c -f -r tests/testkeccak"
-  exec "nim c -f -r tests/testsha2"
-  exec "nim c -f -r tests/testripemd"
-  exec "nim c -f -r tests/testblake2"
-  exec "nim c -f -r tests/testhmac"
-  exec "nim c -f -r tests/testrijndael"
-  exec "nim c -f -r tests/testtwofish"
-  exec "nim c -f -r tests/testblowfish"
-  exec "nim c -f -r tests/testbcmode"
-  exec "nim c -f -r tests/testsysrand"
-  exec "nim c -f -r tests/testkdf"
-  exec "nim c -f -r tests/testapi"
+  for tfile in @[
+      "testkeccak",
+      "testsha2",
+      "testripemd",
+      "testblake2",
+      "testhmac",
+      "testrijndael",
+      "testtwofish",
+      "testblowfish",
+      "testbcmode",
+      "testsysrand",
+      "testkdf",
+      "testapi",
+    ]:
+    for cmd in @[
+        "nim c -f -r tests/" & tfile,
+        "nim c -f -d:release -r tests/" & tfile,
+        "nim c -f -d:release --threads:on -r tests/" & tfile,
+      ]:
+      echo "\n" & cmd
+      exec cmd
+      rmFile("tests/" & tfile.toExe())
 
-  exec "nim c -f -d:release -r tests/testkeccak"
-  exec "nim c -f -d:release -r tests/testsha2"
-  exec "nim c -f -d:release -r tests/testripemd"
-  exec "nim c -f -d:release -r tests/testblake2"
-  exec "nim c -f -d:release -r tests/testhmac"
-  exec "nim c -f -d:release -r tests/testrijndael"
-  exec "nim c -f -d:release -r tests/testtwofish"
-  exec "nim c -f -d:release -r tests/testblowfish"
-  exec "nim c -f -d:release -r tests/testbcmode"
-  exec "nim c -f -d:release -r tests/testsysrand"
-  exec "nim c -f -d:release -r tests/testkdf"
-  exec "nim c -f -d:release -r tests/testapi"
+  for efile in @[
+      "ecb",
+      "cbc",
+      "ofb",
+      "cfb",
+      "ctr",
+      "gcm",
+    ]:
+    for cmd in @[
+        "nim c -f -r examples/" & efile,
+        "nim c -f -r --threads:on examples/" & efile,
+      ]:
+      echo "\n" & cmd
+      exec cmd
+      rmFile("examples/" & efile.toExe())
 
-  exec "nim c -f -d:release --threads:on -r tests/testkeccak"
-  exec "nim c -f -d:release --threads:on -r tests/testsha2"
-  exec "nim c -f -d:release --threads:on -r tests/testripemd"
-  exec "nim c -f -d:release --threads:on -r tests/testblake2"
-  exec "nim c -f -d:release --threads:on -r tests/testhmac"
-  exec "nim c -f -d:release --threads:on -r tests/testrijndael"
-  exec "nim c -f -d:release --threads:on -r tests/testtwofish"
-  exec "nim c -f -d:release --threads:on -r tests/testblowfish"
-  exec "nim c -f -d:release --threads:on -r tests/testbcmode"
-  exec "nim c -f -d:release --threads:on -r tests/testsysrand"
-  exec "nim c -f -d:release --threads:on -r tests/testkdf"
-  exec "nim c -f -d:release --threads:on -r tests/testapi"
-
-  exec "nim c -f -r examples/ecb"
-  exec "nim c -f -r examples/cbc"
-  exec "nim c -f -r examples/ofb"
-  exec "nim c -f -r examples/cfb"
-  exec "nim c -f -r examples/ctr"
-  exec "nim c -f -r examples/gcm"
-
-  exec "nim c -f -r --threads:on examples/ecb"
-  exec "nim c -f -r --threads:on examples/cbc"
-  exec "nim c -f -r --threads:on examples/ofb"
-  exec "nim c -f -r --threads:on examples/cfb"
-  exec "nim c -f -r --threads:on examples/ctr"
-  exec "nim c -f -r --threads:on examples/gcm"


### PR DESCRIPTION
- also delete resulting test binaries instead of having Git ignore them
  along with files already under its control like
  tests/{\*.json,\*.nims,\*.txt} and examples/config.nims