### PR TITLE
Skip 0x prefix

### DIFF
--- a/nimcrypto.nimble
+++ b/nimcrypto.nimble
@@ -27,6 +27,7 @@ task tests, "Runs the test suite":
       "testsysrand",
       "testkdf",
       "testapi",
+      "testutils",
     ]
   let testCommands = @[
       "nim c -f -r tests/",

--- a/nimcrypto/utils.nim
+++ b/nimcrypto/utils.nim
@@ -127,8 +127,8 @@ template skip0xPrefix(hexStr: string): int =
   else: 0
 
 proc hexToBytes*(a: string, result: var openarray[byte]) =
-  doAssert(len(a) == 2 * len(result))
   var i = skip0xPrefix(a)
+  doAssert(len(a) - i == 2 * len(result))
   var k = 0
   var r = 0
   if len(a) > 0:

--- a/nimcrypto/utils.nim
+++ b/nimcrypto/utils.nim
@@ -123,7 +123,8 @@ template PUTU8*(p, o, v) =
 template skip0xPrefix(hexStr: string): int =
   ## Returns the index of the first meaningful char in `hexStr` by skipping
   ## "0x" prefix
-  if hexStr[0] == '0' and hexStr[1] in {'x', 'X'}: 2
+  if hexStr.len == 0: 0
+  elif hexStr[0] == '0' and hexStr[1] in {'x', 'X'}: 2
   else: 0
 
 proc hexToBytes*(a: string, result: var openarray[byte]) =

--- a/nimcrypto/utils.nim
+++ b/nimcrypto/utils.nim
@@ -120,9 +120,15 @@ template GETU8*(p, o): byte =
 template PUTU8*(p, o, v) =
   cast[ptr byte](cast[uint](p) + cast[uint](o))[] = v
 
+template skip0xPrefix(hexStr: string): int =
+  ## Returns the index of the first meaningful char in `hexStr` by skipping
+  ## "0x" prefix
+  if hexStr[0] == '0' and hexStr[1] in {'x', 'X'}: 2
+  else: 0
+
 proc hexToBytes*(a: string, result: var openarray[byte]) =
   doAssert(len(a) == 2 * len(result))
-  var i = 0
+  var i = skip0xPrefix(a)
   var k = 0
   var r = 0
   if len(a) > 0:
@@ -142,7 +148,7 @@ proc hexToBytes*(a: string, result: var openarray[byte]) =
       of '0'..'9':
         r = r or (ord(c) - ord('0'))
       else:
-        doAssert(false)
+        doAssert(false, "Unexpected non-hex character \"" & $c & "\"")
       inc(i)
     result[k] = r.byte
 
@@ -177,7 +183,7 @@ proc toHex*(a: openarray[byte], lowercase: bool = false): string =
 
 proc stripSpaces*(s: string): string =
   result = ""
-  let allowed:set[char] = {'A'..'Z', 'a'..'z', '0'..'9'}
+  const allowed:set[char] = {'A'..'Z', 'a'..'z', '0'..'9'}
   for i in s:
     if i in allowed:
       result &= i

--- a/nimcrypto/utils.nim
+++ b/nimcrypto/utils.nim
@@ -127,14 +127,16 @@ template skip0xPrefix(hexStr: string): int =
   else: 0
 
 proc hexToBytes*(a: string, result: var openarray[byte]) =
-  var i = skip0xPrefix(a)
-  doAssert(len(a) - i == 2 * len(result))
+  let offset = skip0xPrefix(a)
+  let length = len(a) - offset
+  doAssert(length == 2 * len(result))
+  var i = offset
   var k = 0
   var r = 0
-  if len(a) > 0:
+  if length > 0:
     while i < len(a):
       let c = a[i]
-      if i != 0 and i %% 2 == 0:
+      if i != offset and i %% 2 == 0:
         result[k] = r.byte
         r = 0
         inc(k)
@@ -157,7 +159,8 @@ proc fromHex*(a: string): seq[byte] =
   if len(a) == 0:
     result = newSeq[byte]()
   else:
-    result = newSeq[byte](len(a) div 2)
+    let offset = skip0xPrefix(a)
+    result = newSeq[byte]((len(a) - offset) div 2)
     hexToBytes(a, result)
 
 proc hexChar*(c: byte, lowercase: bool = false): string =

--- a/tests/testutils.nim
+++ b/tests/testutils.nim
@@ -1,0 +1,8 @@
+import nimcrypto/utils
+import unittest
+
+suite "Utilities test":
+  test "Can parse hex string with prefix":
+    let a = "0x1234"
+    let b = fromHex(a)
+    check: b == @[byte 0x12, 0x34]


### PR DESCRIPTION
Add a way to skip the 0x prefix.

This is needed to parse the autogenerated test files from the EF test suite.