### PR TITLE
use "openArray" instead of "openarray" for stylecheck

### DIFF
--- a/examples/cbc.nim
+++ b/examples/cbc.nim
@@ -18,7 +18,7 @@ var aliceData = "Alice hidden secret"
 var aliceIv = "0123456789ABCDEF"
 
 block:
-  ## Nim's way API using openarray[byte].
+  ## Nim's way API using openArray[byte].
 
   var ectx, dctx: CBC[aes256]
   var key: array[aes256.sizeKey, byte]

--- a/examples/cfb.nim
+++ b/examples/cfb.nim
@@ -18,7 +18,7 @@ var aliceData = "Alice hidden secret"
 var aliceIv = "0123456789ABCDEF"
 
 block:
-  ## Nim's way API using openarray[byte].
+  ## Nim's way API using openArray[byte].
 
   var ectx, dctx: CFB[aes256]
   var key: array[aes256.sizeKey, byte]

--- a/examples/ctr.nim
+++ b/examples/ctr.nim
@@ -18,7 +18,7 @@ var aliceData = "Alice hidden secret"
 var aliceIv = "0123456789ABCDEF"
 
 block:
-  ## Nim's way API using openarray[byte].
+  ## Nim's way API using openArray[byte].
 
   var ectx, dctx: CTR[aes256]
   var key: array[aes256.sizeKey, byte]

--- a/examples/ecb.nim
+++ b/examples/ecb.nim
@@ -14,7 +14,7 @@ var aliceKey = "Alice Key"
 var aliceData = "Alice hidden secret"
 
 block:
-  ## Nim's way API using openarray[byte].
+  ## Nim's way API using openArray[byte].
 
   var ectx, dctx: ECB[aes256]
   var key: array[aes256.sizeKey, byte]

--- a/examples/gcm.nim
+++ b/examples/gcm.nim
@@ -19,7 +19,7 @@ var aliceData = "Alice hidden secret"
 var aliceIv = "0123456789ABCDEF"
 
 block:
-  ## Nim's way API using openarray[byte].
+  ## Nim's way API using openArray[byte].
 
   var ectx, dctx: GCM[aes256]
   var key: array[aes256.sizeKey, byte]

--- a/examples/ofb.nim
+++ b/examples/ofb.nim
@@ -18,7 +18,7 @@ var aliceData = "Alice hidden secret"
 var aliceIv = "0123456789ABCDEF"
 
 block:
-  ## Nim's way API using openarray[byte].
+  ## Nim's way API using openArray[byte].
 
   var ectx, dctx: OFB[aes256]
   var key: array[aes256.sizeKey, byte]

--- a/nimcrypto/bcmode.nim
+++ b/nimcrypto/bcmode.nim
@@ -89,7 +89,7 @@ template sizeKey*[T](ctx: ECB[T]): int =
   mixin sizeKey
   sizeKey(ctx.cipher)
 
-proc init*[T](ctx: var ECB[T], key: openarray[byte]) {.inline.} =
+proc init*[T](ctx: var ECB[T], key: openArray[byte]) {.inline.} =
   ## Initialize ``ECB[T]`` with encryption key ``key``.
   ##
   ## This procedure will not perform any additional padding for encryption
@@ -103,7 +103,7 @@ proc init*[T](ctx: var ECB[T], key: openarray[byte]) {.inline.} =
   assert(len(key) >= ctx.sizeKey())
   init(ctx.cipher, key)
 
-proc init*[T](ctx: var ECB[T], key: openarray[char]) {.inline.} =
+proc init*[T](ctx: var ECB[T], key: openArray[char]) {.inline.} =
   ## Initialize ``ECB[T]`` with encryption key ``key``.
   ##
   ## This procedure will not perform any additional padding for encryption
@@ -127,8 +127,8 @@ proc clear*[T](ctx: var ECB[T]) {.inline.} =
   ## Clear ``ECB[T]`` context ``ctx``.
   burnMem(ctx)
 
-proc encrypt*[T](ctx: var ECB[T], input: openarray[byte],
-                 output: var openarray[byte]) {.inline.} =
+proc encrypt*[T](ctx: var ECB[T], input: openArray[byte],
+                 output: var openArray[byte]) {.inline.} =
   ## Encrypt array of data ``input`` and store encrypted data to array
   ## ``output`` using ``ECB[T]`` context ``ctx``.
   ##
@@ -147,8 +147,8 @@ proc encrypt*[T](ctx: var ECB[T], input: openarray[byte],
                        output.toOpenArray(offset, offset + ctx.sizeBlock() - 1))
     offset = offset + ctx.sizeBlock()
 
-proc encrypt*[T](ctx: var ECB[T], input: openarray[char],
-                 output: var openarray[char]) {.inline.} =
+proc encrypt*[T](ctx: var ECB[T], input: openArray[char],
+                 output: var openArray[char]) {.inline.} =
   ## Encrypt array of data ``input`` and store encrypted data to array
   ## ``output`` using ``ECB[T]`` context ``ctx``.
   ##
@@ -161,8 +161,8 @@ proc encrypt*[T](ctx: var ECB[T], input: openarray[char],
   encrypt(ctx, input.toOpenArrayByte(0, len(input) - 1),
           output.toOpenArrayByte(0, len(output) - 1))
 
-proc decrypt*[T](ctx: var ECB[T], input: openarray[byte],
-                 output: var openarray[byte]) {.inline.} =
+proc decrypt*[T](ctx: var ECB[T], input: openArray[byte],
+                 output: var openArray[byte]) {.inline.} =
   ## Decrypt array of data ``input`` and store decrypted data to array
   ## ``output`` using ``ECB[T]`` context ``ctx``.
   ##
@@ -181,8 +181,8 @@ proc decrypt*[T](ctx: var ECB[T], input: openarray[byte],
                        output.toOpenArray(offset, offset + ctx.sizeBlock() - 1))
     offset = offset + ctx.sizeBlock()
 
-proc decrypt*[T](ctx: var ECB[T], input: openarray[char],
-                 output: var openarray[char]) {.inline.} =
+proc decrypt*[T](ctx: var ECB[T], input: openArray[char],
+                 output: var openArray[char]) {.inline.} =
   ## Decrypt array of data ``input`` and store decrypted data to array
   ## ``output`` using ``ECB[T]`` context ``ctx``.
   ##
@@ -243,7 +243,7 @@ template sizeKey*[T](ctx: CBC[T]): int =
   mixin sizeKey
   sizeKey(ctx.cipher)
 
-proc init*[T](ctx: var CBC[T], key: openarray[byte], iv: openarray[byte]) =
+proc init*[T](ctx: var CBC[T], key: openArray[byte], iv: openArray[byte]) =
   ## Initialize ``CBC[T]`` with encryption key ``key`` and initial vector (IV)
   ## ``iv``.
   ##
@@ -261,7 +261,7 @@ proc init*[T](ctx: var CBC[T], key: openarray[byte], iv: openarray[byte]) =
   init(ctx.cipher, key)
   ctx.iv[0 ..< ctx.sizeBlock()] = iv.toOpenArray(0, ctx.sizeBlock() - 1)
 
-proc init*[T](ctx: var CBC[T], key: openarray[char], iv: openarray[char]) =
+proc init*[T](ctx: var CBC[T], key: openArray[char], iv: openArray[char]) =
   ## Initialize ``CBC[T]`` with encryption key ``key`` and initial vector (IV)
   ## ``iv``.
   ##
@@ -294,8 +294,8 @@ proc clear*[T](ctx: var CBC[T]) {.inline.} =
   ## Clear ``CBC[T]`` context ``ctx``.
   burnMem(ctx)
 
-proc encrypt*[T](ctx: var CBC[T], input: openarray[byte],
-                 output: var openarray[byte]) {.inline.} =
+proc encrypt*[T](ctx: var CBC[T], input: openArray[byte],
+                 output: var openArray[byte]) {.inline.} =
   ## Encrypt array of data ``input`` and store encrypted data to array
   ## ``output`` using ``CBC[T]`` context ``ctx``.
   ##
@@ -335,8 +335,8 @@ proc encrypt*[T](ctx: var CBC[T], inp: ptr byte, oup: ptr byte,
                toOpenArray(op[], 0, int(length - 1)))
   result = length
 
-proc encrypt*[T](ctx: var CBC[T], input: openarray[char],
-                 output: var openarray[char]) {.inline.} =
+proc encrypt*[T](ctx: var CBC[T], input: openArray[char],
+                 output: var openArray[char]) {.inline.} =
   ## Encrypt array of data ``input`` and store encrypted data to array
   ## ``output`` using ``CBC[T]`` context ``ctx``.
   ##
@@ -349,8 +349,8 @@ proc encrypt*[T](ctx: var CBC[T], input: openarray[char],
   encrypt(ctx, input.toOpenArrayByte(0, len(input) - 1),
                output.toOpenArrayByte(0, len(output) - 1))
 
-proc decrypt*[T](ctx: var CBC[T], input: openarray[byte],
-                 output: var openarray[byte]) {.inline.} =
+proc decrypt*[T](ctx: var CBC[T], input: openArray[byte],
+                 output: var openArray[byte]) {.inline.} =
   ## Decrypt array of data ``input`` and store decrypted data to array
   ## ``output`` using ``CBC[T]`` context ``ctx``.
   ##
@@ -390,8 +390,8 @@ proc decrypt*[T](ctx: var CBC[T], inp: ptr byte, oup: ptr byte,
                toOpenArray(op[], 0, int(length - 1)))
   result = length
 
-proc decrypt*[T](ctx: var CBC[T], input: openarray[char],
-                 output: var openarray[char]) {.inline.} =
+proc decrypt*[T](ctx: var CBC[T], input: openArray[char],
+                 output: var openArray[char]) {.inline.} =
   ## Decrypt array of data ``input`` and store decrypted data to array
   ## ``output`` using ``CBC[T]`` context ``ctx``.
   ##
@@ -418,7 +418,7 @@ template sizeKey*[T](ctx: CTR[T]): int =
   mixin sizeKey
   sizeKey(ctx.cipher)
 
-proc inc128(counter: var openarray[byte]) =
+proc inc128(counter: var openArray[byte]) =
   var n = 16'u32
   var c = 1'u32
   while true:
@@ -429,7 +429,7 @@ proc inc128(counter: var openarray[byte]) =
     if n == 0:
       break
 
-proc inc256(counter: var openarray[byte]) =
+proc inc256(counter: var openArray[byte]) =
   var n = 32'u32
   var c = 1'u32
   while true:
@@ -440,7 +440,7 @@ proc inc256(counter: var openarray[byte]) =
     if n == 0:
       break
 
-proc init*[T](ctx: var CTR[T], key: openarray[byte], iv: openarray[byte]) =
+proc init*[T](ctx: var CTR[T], key: openArray[byte], iv: openArray[byte]) =
   ## Initialize ``CTR[T]`` with encryption key ``key`` and initial vector (IV)
   ## ``iv``.
   ##
@@ -473,8 +473,8 @@ proc init*[T](ctx: var CTR[T], key: ptr byte, iv: ptr byte) =
   init(ctx, toOpenArray(pkey[], 0, ctx.sizeKey() - 1),
             toOpenArray(piv[], 0, ctx.sizeBlock() - 1))
 
-proc init*[T](ctx: var CTR[T], key: openarray[char],
-              iv: openarray[char]) {.inline.} =
+proc init*[T](ctx: var CTR[T], key: openArray[char],
+              iv: openArray[char]) {.inline.} =
   ## Initialize ``CTR[T]`` with encryption key ``key`` and initial vector (IV)
   ## ``iv``.
   ##
@@ -492,8 +492,8 @@ proc clear*[T](ctx: var CTR[T]) {.inline.} =
   ## Clear ``CTR[T]`` context ``ctx``.
   burnMem(ctx)
 
-proc encrypt*[T](ctx: var CTR[T], input: openarray[byte],
-                 output: var openarray[byte]) {.inline.} =
+proc encrypt*[T](ctx: var CTR[T], input: openArray[byte],
+                 output: var openArray[byte]) {.inline.} =
   ## Perform ``CTR[T]`` encryption of plain data array ``input`` and store
   ## encrypted data to array ``output`` using ``CTR[T]`` context ``ctx``.
   ##
@@ -517,8 +517,8 @@ proc encrypt*[T](ctx: var CTR[T], input: openarray[byte],
     n = (n + 1) mod ctx.sizeBlock()
   ctx.num = n
 
-proc encrypt*[T](ctx: var CTR[T], input: openarray[char],
-                 output: var openarray[char]) {.inline.} =
+proc encrypt*[T](ctx: var CTR[T], input: openArray[char],
+                 output: var openArray[char]) {.inline.} =
   ## Perform ``CTR[T]`` encryption of plain data array ``input`` and store
   ## encrypted data to array ``output`` using ``CTR[T]`` context ``ctx``.
   ##
@@ -540,8 +540,8 @@ proc encrypt*[T](ctx: var CTR[T], inp: ptr byte, oup: ptr byte,
                toOpenArray(op[], 0, int(length - 1)))
   result = length
 
-proc decrypt*[T](ctx: var CTR[T], input: openarray[byte],
-                 output: var openarray[byte]) {.inline.} =
+proc decrypt*[T](ctx: var CTR[T], input: openArray[byte],
+                 output: var openArray[byte]) {.inline.} =
   ## Perform ``CTR[T]`` decryption of encrypted data array ``input`` and
   ## store decrypted data to array ``output`` using ``CTR[T]`` context ``ctx``.
   ##
@@ -562,8 +562,8 @@ proc decrypt*[T](ctx: var CTR[T], inp: ptr byte, oup: ptr byte,
                toOpenArray(op[], 0, int(length - 1)))
   result = length
 
-proc decrypt*[T](ctx: var CTR[T], input: openarray[char],
-                 output: var openarray[char]) {.inline.} =
+proc decrypt*[T](ctx: var CTR[T], input: openArray[char],
+                 output: var openArray[char]) {.inline.} =
   ## Perform ``CTR[T]`` decryption of encrypted data array ``input`` and
   ## store decrypted data to array ``output`` using ``CTR[T]`` context ``ctx``.
   ##
@@ -586,7 +586,7 @@ template sizeKey*[T](ctx: OFB[T]): int =
   mixin sizeKey
   sizeKey(ctx.cipher)
 
-proc init*[T](ctx: var OFB[T], key: openarray[byte], iv: openarray[byte]) =
+proc init*[T](ctx: var OFB[T], key: openArray[byte], iv: openArray[byte]) =
   ## Initialize ``OFB[T]`` with encryption key ``key`` and initial vector (IV)
   ## ``iv``.
   ##
@@ -619,7 +619,7 @@ proc init*[T](ctx: var OFB[T], key: ptr byte, iv: ptr byte) =
   init(ctx, toOpenArray(pkey[], 0, ctx.sizeKey() - 1),
             toOpenArray(piv[], 0, ctx.sizeBlock() - 1))
 
-proc init*[T](ctx: var OFB[T], key: openarray[char], iv: openarray[char]) =
+proc init*[T](ctx: var OFB[T], key: openArray[char], iv: openArray[char]) =
   ## Initialize ``OFB[T]`` with encryption key ``key`` and initial vector (IV)
   ## ``iv``.
   ##
@@ -637,8 +637,8 @@ proc clear*[T](ctx: var OFB[T]) {.inline.} =
   ## Clear ``OFB[T]`` context ``ctx``.
   burnMem(ctx)
 
-proc encrypt*[T](ctx: var OFB[T], input: openarray[byte],
-                 output: var openarray[byte]) {.inline.} =
+proc encrypt*[T](ctx: var OFB[T], input: openArray[byte],
+                 output: var openArray[byte]) {.inline.} =
   ## Encrypt array of data ``input`` and store encrypted data to array
   ## ``output`` using ``OFB[T]`` context ``ctx``.
   ##
@@ -668,8 +668,8 @@ proc encrypt*[T](ctx: var OFB[T], inp: ptr byte, oup: ptr byte,
                toOpenArray(op[], 0, int(length - 1)))
   result = length
 
-proc encrypt*[T](ctx: var OFB[T], input: openarray[char],
-                 output: var openarray[char]) {.inline.} =
+proc encrypt*[T](ctx: var OFB[T], input: openArray[char],
+                 output: var openArray[char]) {.inline.} =
   ## Encrypt array of data ``input`` and store encrypted data to array
   ## ``output`` using ``OFB[T]`` context ``ctx``.
   ##
@@ -678,8 +678,8 @@ proc encrypt*[T](ctx: var OFB[T], input: openarray[char],
   encrypt(ctx, input.toOpenArrayByte(0, len(input) - 1),
                output.toOpenArrayByte(0, len(output) - 1))
 
-proc decrypt*[T](ctx: var OFB[T], input: openarray[byte],
-                 output: var openarray[byte]) {.inline.} =
+proc decrypt*[T](ctx: var OFB[T], input: openArray[byte],
+                 output: var openArray[byte]) {.inline.} =
   ## Decrypt array of data ``input`` and store decrypted data to array
   ## ``output`` using ``OFB[T]`` context ``ctx``.
   ##
@@ -700,8 +700,8 @@ proc decrypt*[T](ctx: var OFB[T], inp: ptr byte, oup: ptr byte,
                toOpenArray(op[], 0, int(length - 1)))
   result = length
 
-proc decrypt*[T](ctx: var OFB[T], input: openarray[char],
-                 output: var openarray[char]) {.inline.} =
+proc decrypt*[T](ctx: var OFB[T], input: openArray[char],
+                 output: var openArray[char]) {.inline.} =
   ## Decrypt array of data ``input`` and store decrypted data to array
   ## ``output`` using ``OFB[T]`` context ``ctx``.
   ##
@@ -724,7 +724,7 @@ template sizeKey*[T](ctx: CFB[T]): int =
   mixin sizeKey
   sizeKey(ctx.cipher)
 
-proc init*[T](ctx: var CFB[T], key: openarray[byte], iv: openarray[byte]) =
+proc init*[T](ctx: var CFB[T], key: openArray[byte], iv: openArray[byte]) =
   ## Initialize ``CFB[T]`` with encryption key ``key`` and initial vector (IV)
   ## ``iv``.
   ##
@@ -757,7 +757,7 @@ proc init*[T](ctx: var CFB[T], key: ptr byte, iv: ptr byte) =
   init(ctx, toOpenArray(pkey[], 0, ctx.sizeKey() - 1),
             toOpenArray(piv[], 0, ctx.sizeBlock() - 1))
 
-proc init*[T](ctx: var CFB[T], key: openarray[char], iv: openarray[char]) =
+proc init*[T](ctx: var CFB[T], key: openArray[char], iv: openArray[char]) =
   ## Initialize ``CFB[T]`` with encryption key ``key`` and initial vector (IV)
   ## ``iv``.
   ##
@@ -775,8 +775,8 @@ proc clear*[T](ctx: var CFB[T]) {.inline.} =
   ## Clear ``CFB[T]`` context ``ctx``.
   burnMem(ctx)
 
-proc encrypt*[T](ctx: var CFB[T], input: openarray[byte],
-                 output: var openarray[byte]) {.inline.} =
+proc encrypt*[T](ctx: var CFB[T], input: openArray[byte],
+                 output: var openArray[byte]) {.inline.} =
   ## Encrypt array of data ``input`` and store encrypted data to array
   ## ``output`` using ``CFB[T]`` context ``ctx``.
   ##
@@ -807,8 +807,8 @@ proc encrypt*[T](ctx: var CFB[T], inp: ptr byte, oup: ptr byte,
                toOpenArray(op[], 0, int(length - 1)))
   result = length
 
-proc encrypt*[T](ctx: var CFB[T], input: openarray[char],
-                 output: var openarray[char]) {.inline.} =
+proc encrypt*[T](ctx: var CFB[T], input: openArray[char],
+                 output: var openArray[char]) {.inline.} =
   ## Encrypt array of data ``input`` and store encrypted data to array
   ## ``output`` using ``CFB[T]`` context ``ctx``.
   ##
@@ -817,8 +817,8 @@ proc encrypt*[T](ctx: var CFB[T], input: openarray[char],
   encrypt(ctx, input.toOpenArrayByte(0, len(input) - 1),
                output.toOpenArrayByte(0, len(output) - 1))
 
-proc decrypt*[T](ctx: var CFB[T], input: openarray[byte],
-                 output: var openarray[byte]) =
+proc decrypt*[T](ctx: var CFB[T], input: openArray[byte],
+                 output: var openArray[byte]) =
   ## Decrypt array of data ``input`` and store decrypted data to array
   ## ``output`` using ``CFB[T]`` context ``ctx``.
   ##
@@ -850,8 +850,8 @@ proc decrypt*[T](ctx: var CFB[T], inp: ptr byte, oup: ptr byte,
                toOpenArray(op[], 0, int(length - 1)))
   result = length
 
-proc decrypt*[T](ctx: var CFB[T], input: openarray[char],
-                 output: var openarray[char]) =
+proc decrypt*[T](ctx: var CFB[T], input: openArray[char],
+                 output: var openArray[char]) =
   ## Decrypt array of data ``input`` and store decrypted data to array
   ## ``output`` using ``CFB[T]`` context ``ctx``.
   ##
@@ -898,8 +898,8 @@ proc rev64(x: uint64): uint64 =
   RMS(xx, 0x0000FFFF0000FFFF'u64, 16)
   result = (xx shl 32) or (xx shr 32)
 
-proc ghash(y: var openarray[byte], h: openarray[byte],
-           data: openarray[byte]) =
+proc ghash(y: var openArray[byte], h: openArray[byte],
+           data: openArray[byte]) =
   var  y0, y1, h0, h1, h2, h0r, h1r, h2r: uint64
 
   y1 = beLoad64(y, 0)
@@ -979,8 +979,8 @@ template sizeKey*[T](ctx: GCM[T]): int =
   mixin sizeKey
   sizeKey(ctx.cipher)
 
-proc init*[T](ctx: var GCM[T], key: openarray[byte], iv: openarray[byte],
-              aad: openarray[byte]) =
+proc init*[T](ctx: var GCM[T], key: openArray[byte], iv: openArray[byte],
+              aad: openArray[byte]) =
   ## Initialize ``GCM[T]`` with encryption key ``key``, initial vector (IV)
   ## ``iv`` and additional authentication data (AAD) ``aad``.
   ##
@@ -1009,8 +1009,8 @@ proc init*[T](ctx: var GCM[T], key: openarray[byte], iv: openarray[byte],
   if len(aad) > 0:
     ghash(ctx.buf, ctx.h, aad)
 
-proc encrypt*[T](ctx: var GCM[T], input: openarray[byte],
-                 output: var openarray[byte]) =
+proc encrypt*[T](ctx: var GCM[T], input: openArray[byte],
+                 output: var openArray[byte]) =
   ## Encrypt array of data ``input`` and store encrypted data to array
   ## ``output`` using ``GCM[T]`` context ``ctx``.
   ##
@@ -1033,8 +1033,8 @@ proc encrypt*[T](ctx: var GCM[T], input: openarray[byte],
     length -= uselen
     offset += uselen
 
-proc decrypt*[T](ctx: var GCM[T], input: openarray[byte],
-                 output: var openarray[byte]) =
+proc decrypt*[T](ctx: var GCM[T], input: openArray[byte],
+                 output: var openArray[byte]) =
   ## Decrypt array of data ``input`` and store decrypted data to array
   ## ``output`` using ``GCM[T]`` context ``ctx``.
   ##
@@ -1057,7 +1057,7 @@ proc decrypt*[T](ctx: var GCM[T], input: openarray[byte],
     length -= uselen
     offset += uselen
 
-proc getTag*[T](ctx: var GCM[T], tag: var openarray[byte]) =
+proc getTag*[T](ctx: var GCM[T], tag: var openArray[byte]) =
   ## Obtain authentication tag from ``GCM[T]`` context ``ctx`` and store it to
   ## ``tag``.
   ##

--- a/nimcrypto/blake2.nim
+++ b/nimcrypto/blake2.nim
@@ -285,7 +285,7 @@ template sizeBlock*(r: typedesc[blake2]): int =
   else:
     (128)
 
-proc init*[T: bchar](ctx: var Blake2Context, key: openarray[T]) {.inline.} =
+proc init*[T: bchar](ctx: var Blake2Context, key: openArray[T]) {.inline.} =
   when ctx is Blake2sContext:
     when nimvm:
       for i in 0 ..< 64:
@@ -382,7 +382,7 @@ proc reset*(ctx: var Blake2Context) {.inline.} =
   ctx.t[1] = ctx.tb[1]
   ctx.c = ctx.cb
 
-proc update*[T: bchar](ctx: var Blake2Context, data: openarray[T]) {.inline.} =
+proc update*[T: bchar](ctx: var Blake2Context, data: openArray[T]) {.inline.} =
   var i = 0
   while i < len(data):
     if ctx.c == int(ctx.sizeBlock):
@@ -409,7 +409,7 @@ proc update*(ctx: var Blake2Context, pbytes: ptr byte,
   ctx.update(toOpenArray(p[], 0, int(nbytes) - 1))
 
 proc finish*(ctx: var Blake2sContext,
-             data: var openarray[byte]): uint {.inline, discardable.} =
+             data: var openArray[byte]): uint {.inline, discardable.} =
   ctx.t[0] = ctx.t[0] + uint32(ctx.c)
   if ctx.t[0] < uint32(ctx.c):
     ctx.t[1] = ctx.t[1] + 1
@@ -423,7 +423,7 @@ proc finish*(ctx: var Blake2sContext,
     data[i] = byte((ctx.h[i shr 2] shr (8 * (i and 3))) and 0xFF'u32)
 
 proc finish*(ctx: var Blake2bContext,
-             data: var openarray[byte]): uint {.inline, discardable.} =
+             data: var openArray[byte]): uint {.inline, discardable.} =
   ctx.t[0] = ctx.t[0] + uint64(ctx.c)
   if ctx.t[0] < uint64(ctx.c):
     ctx.t[1] = ctx.t[1] + 1'u64

--- a/nimcrypto/blowfish.nim
+++ b/nimcrypto/blowfish.nim
@@ -336,8 +336,8 @@ template f(ctx: var BlowfishContext, x: uint32): uint32 =
   vy = vy + ctx.S[3][d]
   vy
 
-proc blowfishEncrypt*(ctx: var BlowfishContext, inp: openarray[byte],
-                      oup: var openarray[byte]) =
+proc blowfishEncrypt*(ctx: var BlowfishContext, inp: openArray[byte],
+                      oup: var openArray[byte]) =
   var nxl = leLoad32(inp, 0)
   var nxr = leLoad32(inp, 4)
 
@@ -362,8 +362,8 @@ proc blowfishEncrypt*(ctx: var BlowfishContext, inp: openarray[byte],
   leStore32(oup, 0, nxl)
   leStore32(oup, 4, nxr)
 
-proc blowfishDecrypt*(ctx: var BlowfishContext, inp: openarray[byte],
-                      oup: var openarray[byte]) =
+proc blowfishDecrypt*(ctx: var BlowfishContext, inp: openArray[byte],
+                      oup: var openArray[byte]) =
 
   var nxl = leLoad32(inp, 0)
   var nxr = leLoad32(inp, 4)
@@ -388,7 +388,7 @@ proc blowfishDecrypt*(ctx: var BlowfishContext, inp: openarray[byte],
   leStore32(oup, 0, nxl)
   leStore32(oup, 4, nxr)
 
-proc initBlowfishContext*(ctx: var BlowfishContext, key: openarray[byte],
+proc initBlowfishContext*(ctx: var BlowfishContext, key: openArray[byte],
                           nkey: int) =
   var i = 0
   var j = 0
@@ -448,7 +448,7 @@ template sizeKey*(r: typedesc[blowfish]): int =
 template sizeBlock*(r: typedesc[blowfish]): int =
   (8)
 
-proc init*(ctx: var BlowfishContext, key: openarray[byte]) {.inline.} =
+proc init*(ctx: var BlowfishContext, key: openArray[byte]) {.inline.} =
   ctx.sizeKey = len(key) shl 3
   initBlowfishContext(ctx, key, ctx.sizeKey)
 
@@ -461,12 +461,12 @@ proc init*(ctx: var BlowfishContext, key: ptr byte, nkey: int) {.inline.} =
 proc clear*(ctx: var BlowfishContext) {.inline.} =
   burnMem(ctx)
 
-proc encrypt*(ctx: var BlowfishContext, input: openarray[byte],
-              output: var openarray[byte]) {.inline.} =
+proc encrypt*(ctx: var BlowfishContext, input: openArray[byte],
+              output: var openArray[byte]) {.inline.} =
   blowfishEncrypt(ctx, input, output)
 
-proc decrypt*(ctx: var BlowfishContext, input: openarray[byte],
-              output: var openarray[byte]) {.inline.} =
+proc decrypt*(ctx: var BlowfishContext, input: openArray[byte],
+              output: var openArray[byte]) {.inline.} =
   blowfishDecrypt(ctx, input, output)
 
 proc encrypt*(ctx: var BlowfishContext, inbytes: ptr byte,

--- a/nimcrypto/hash.nim
+++ b/nimcrypto/hash.nim
@@ -68,7 +68,7 @@ proc digest*(HashType: typedesc, data: ptr byte,
   ctx.clear()
 
 proc digest*[T: bchar](HashType: typedesc,
-                       data: openarray[T]): MDigest[HashType.bits] =
+                       data: openArray[T]): MDigest[HashType.bits] =
   ## Calculate and return digest using algorithm ``HashType`` of data ``data``
   ##
   ##  .. code-block::nim
@@ -92,7 +92,7 @@ proc digest*[T: bchar](HashType: typedesc,
   result = ctx.finish()
   ctx.clear()
 
-proc digest*[T](HashType: typedesc, data: openarray[T],
+proc digest*[T](HashType: typedesc, data: openArray[T],
                 ostart: int, ofinish = -1): MDigest[HashType.bits] {.
      deprecated: "Use digest(data.toOpenArray()) instead", inline.} =
   if ofinish < 0:

--- a/nimcrypto/hmac.nim
+++ b/nimcrypto/hmac.nim
@@ -98,10 +98,10 @@ template sizeDigest*[T](h: HMAC[T]): uint =
   ## Size of HMAC digest in octets (bytes).
   uint(h.mdctx.sizeDigest)
 
-proc init*[T, M](hmctx: var HMAC[T], key: openarray[M]) =
+proc init*[T, M](hmctx: var HMAC[T], key: openArray[M]) =
   ## Initialize HMAC context ``hmctx`` with key using ``key`` array.
   ##
-  ## ``key`` supports ``openarray[byte]`` and ``openarray[char]`` only.
+  ## ``key`` supports ``openArray[byte]`` and ``openArray[char]`` only.
   mixin init, update, finish
 
   when not((M is byte) or (M is char)):
@@ -155,7 +155,7 @@ proc reset*(hmctx: var HMAC) =
   update(hmctx.mdctx, hmctx.ipad)
   update(hmctx.opadctx, hmctx.opad)
 
-proc update*[T: bchar](hmctx: var HMAC, data: openarray[T]) {.inline.} =
+proc update*[T: bchar](hmctx: var HMAC, data: openArray[T]) {.inline.} =
   ## Update HMAC context ``hmctx`` with data array ``data``. Repeated calls are
   ## equivalent to a single call with the concatenation of all ``data``
   ## arguments.
@@ -195,7 +195,7 @@ proc update*(hmctx: var HMAC, pbytes: ptr byte, nbytes: uint) {.inline.} =
   hmctx.update(ptrarr[].toOpenArray(0, int(nbytes) - 1))
 
 proc finish*[T: bchar](hmctx: var HMAC,
-                       data: var openarray[T]): uint {.inline.} =
+                       data: var openArray[T]): uint {.inline.} =
   ## Finalize HMAC context ``hmctx`` and store calculated digest to array
   ## ``data``. ``data`` length must be at least ``hmctx.sizeDigest`` octets
   ## (bytes).
@@ -218,8 +218,8 @@ proc finish*(hmctx: var HMAC): MDigest[hmctx.HashType.bits] =
   ## ``MDigest`` object.
   discard finish(hmctx, result.data)
 
-proc hmac*[A: bchar, B: bchar](HashType: typedesc, key: openarray[A],
-                               data: openarray[B]): MDigest[HashType.bits] =
+proc hmac*[A: bchar, B: bchar](HashType: typedesc, key: openArray[A],
+                               data: openArray[B]): MDigest[HashType.bits] =
   ## Perform HMAC computation with hash algorithm ``HashType`` using key ``key``
   ## of data ``data``.
   ##

--- a/nimcrypto/keccak.nim
+++ b/nimcrypto/keccak.nim
@@ -60,27 +60,27 @@ type
 # then 256 registers and so it is not enough for it to perform round in
 # template.
 when nimvm:
-  proc THETA1(a: var openarray[uint64], b: openarray[uint64],
+  proc THETA1(a: var openArray[uint64], b: openArray[uint64],
               c: int) {.inline.} =
     a[c] = b[c] xor b[c + 5] xor b[c + 10] xor b[c + 15] xor b[c + 20]
 
-  proc THETA2(a: var uint64, b: openarray[uint64], c: int) {.inline.} =
+  proc THETA2(a: var uint64, b: openArray[uint64], c: int) {.inline.} =
     a = b[(c + 4) mod 5] xor ROL(uint64(b[(c + 1) mod 5]), 1)
 
-  proc THETA3(a: var openarray[uint64], b: int, c: uint64) {.inline.} =
+  proc THETA3(a: var openArray[uint64], b: int, c: uint64) {.inline.} =
     a[b] = a[b] xor c
     a[b + 5] = a[b + 5] xor c
     a[b + 10] = a[b + 10] xor c
     a[b + 15] = a[b + 15] xor c
     a[b + 20] = a[b + 20] xor c
 
-  proc RHOPI(a: var openarray[uint64], b: var openarray[uint64], c: var uint64,
+  proc RHOPI(a: var openArray[uint64], b: var openArray[uint64], c: var uint64,
              d, e: int) {.inline.} =
     a[0] = b[d]
     b[d] = ROL(c, e)
     c = uint64(a[0])
 
-  proc CHI(a: var openarray[uint64], b: var openarray[uint64],
+  proc CHI(a: var openArray[uint64], b: var openArray[uint64],
            c: int) {.inline.} =
     a[0] = b[c]
     a[1] = b[c + 1]
@@ -94,7 +94,7 @@ when nimvm:
     b[c + 4] = b[c + 4] xor (not(a[0]) and a[1])
 
 
-  proc KECCAKROUNDP(a: var openarray[uint64], b: var openarray[uint64],
+  proc KECCAKROUNDP(a: var openArray[uint64], b: var openArray[uint64],
                     c: var uint64, r: int) {.inline.} =
     THETA1(b, a, 0)
     THETA1(b, a, 1)
@@ -364,7 +364,7 @@ proc reset*(ctx: var KeccakContext) {.inline.} =
   init(ctx)
 
 proc update*[T: bchar](ctx: var KeccakContext,
-                       data: openarray[T]) {.inline.} =
+                       data: openArray[T]) {.inline.} =
   var j = ctx.pt
   if len(data) > 0:
     for i in 0 ..< len(data):
@@ -392,7 +392,7 @@ proc xof*(ctx: var KeccakContext) {.inline.} =
   ctx.pt = 0
 
 proc output*(ctx: var KeccakContext,
-             data: var openarray[byte]): uint {.inline.} =
+             data: var openArray[byte]): uint {.inline.} =
   when ctx.kind != Shake:
     {.error: "Only `Shake128` and `Shake256` types are supported".}
   var j = ctx.pt
@@ -412,7 +412,7 @@ proc output*(ctx: var KeccakContext, pbytes: ptr byte,
   result = ctx.output(ptrarr[].toOpenArray(0, int(nbytes) - 1))
 
 proc finish*(ctx: var KeccakContext,
-             data: var openarray[byte]): uint {.inline, discardable.} =
+             data: var openArray[byte]): uint {.inline, discardable.} =
   when ctx.kind == Sha3:
     ctx.q[ctx.pt] = ctx.q[ctx.pt] xor 0x06'u8
   else:

--- a/nimcrypto/pbkdf2.nim
+++ b/nimcrypto/pbkdf2.nim
@@ -15,9 +15,9 @@
 import hmac, utils
 export hmac
 
-proc pbkdf2*[T, M, N](ctx: var HMAC[T], password: openarray[M],
-                      salt: openarray[N], c: int,
-                      output: var openarray[byte]): int =
+proc pbkdf2*[T, M, N](ctx: var HMAC[T], password: openArray[M],
+                      salt: openArray[N], c: int,
+                      output: var openArray[byte]): int =
   ## Calculate PBKDF2 result using HMAC algorithm `ctx`.
   ##
   ## ``ctx``      - HMAC[T] context
@@ -74,9 +74,9 @@ proc pbkdf2*[T, M, N](ctx: var HMAC[T], password: openarray[M],
   ctx.clear()
   int(glength)
 
-proc pbkdf2*[T, M, N](ctx: var HMAC[T], password: openarray[M],
-                      salt: openarray[N], c: int,
-                      output: var openarray[byte], outlen: int): int {.
+proc pbkdf2*[T, M, N](ctx: var HMAC[T], password: openArray[M],
+                      salt: openArray[N], c: int,
+                      output: var openArray[byte], outlen: int): int {.
      deprecated: "Use pbkdf2() with output.toOpenArray()", inline.} =
   ## Calculate PBKDF2 result using HMAC algorithm `ctx`.
   ##
@@ -93,8 +93,8 @@ proc pbkdf2*[T, M, N](ctx: var HMAC[T], password: openarray[M],
   else:
     pbkdf2(ctx, password, salt, c, output.toOpenArray(0, outlen))
 
-proc pbkdf2*[T, M](hashtype: typedesc, password: openarray[T],
-                   salt: openarray[M], c: int,
+proc pbkdf2*[T, M](hashtype: typedesc, password: openArray[T],
+                   salt: openArray[M], c: int,
                    outlen: int): seq[byte] {.inline.} =
   ## Calculate PBKDF2 result using HMAC[``hashtype``] algorithm.
   ##

--- a/nimcrypto/rijndael.nim
+++ b/nimcrypto/rijndael.nim
@@ -239,7 +239,7 @@ when sizeof(int) == 4:
     q[1] = q3 xor q6 xor q0
     q[0] = q2 xor q5 xor q7
 
-  proc ortho(q: var openarray[uint32]) {.inline.} =
+  proc ortho(q: var openArray[uint32]) {.inline.} =
     template swapN(cl, ch, s, x, y) =
       var a, b: uint32
       a = x
@@ -284,7 +284,7 @@ when sizeof(int) == 4:
     ortho(q)
     q[0]
 
-  proc keySchedule(ctx: var RijndaelContext, key: openarray[byte]) =
+  proc keySchedule(ctx: var RijndaelContext, key: openArray[byte]) =
     var tmp = 0'u32
     var j, k: int
 
@@ -459,8 +459,8 @@ when sizeof(int) == 4:
     q[6] = q3 xor q4 xor q5 xor q7 xor r3 xor r5 xor r6 xor r7 xor rotr16(v6)
     q[7] = q4 xor q5 xor q6 xor r4 xor r6 xor r7 xor rotr16(v7)
 
-  proc encrypt*(ctx: RijndaelContext, input: openarray[byte],
-                output: var openarray[byte]) =
+  proc encrypt*(ctx: RijndaelContext, input: openArray[byte],
+                output: var openArray[byte]) =
     var q {.noinit.}: array[8, uint32]
     q[0] = leLoad32(input, 0)
     q[2] = leLoad32(input, 4)
@@ -487,8 +487,8 @@ when sizeof(int) == 4:
     leStore32(output, 8, q[4])
     leStore32(output, 12, q[6])
 
-  proc decrypt*(ctx: RijndaelContext, input: openarray[byte],
-                output: var openarray[byte]) =
+  proc decrypt*(ctx: RijndaelContext, input: openArray[byte],
+                output: var openArray[byte]) =
     var q {.noinit.}: array[8, uint32]
     q[0] = leLoad32(input, 0)
     q[2] = leLoad32(input, 4)
@@ -743,7 +743,7 @@ elif sizeof(int) == 8:
     swap8(q[3], q[7])
 
   proc interleaveIn(q0: var uint64, q1: var uint64,
-                    w: openarray[uint32]) {.inline.} =
+                    w: openArray[uint32]) {.inline.} =
     var x0, x1, x2, x3: uint64
 
     x0 = w[0]
@@ -769,7 +769,7 @@ elif sizeof(int) == 8:
     q0 = x0 or (x2 shl 8)
     q1 = x1 or (x3 shl 8)
 
-  proc interleaveOut(w: var openarray[uint32], q0: uint64,
+  proc interleaveOut(w: var openArray[uint32], q0: uint64,
                      q1: uint64) {.inline.} =
     var x0, x1, x2, x3: uint64
 
@@ -802,7 +802,7 @@ elif sizeof(int) == 8:
     ortho(q)
     uint32(q[0] and 0xFFFF_FFFF'u64)
 
-  proc keySchedule(ctx: var RijndaelContext, key: openarray[byte]) =
+  proc keySchedule(ctx: var RijndaelContext, key: openArray[byte]) =
     var skey: array[60, uint32]
     var tkey: array[30, uint64]
     var tmp = 0'u32
@@ -997,8 +997,8 @@ elif sizeof(int) == 8:
     q[6] = q3 xor q4 xor q5 xor q7 xor r3 xor r5 xor r6 xor r7 xor rotr32(v6)
     q[7] = q4 xor q5 xor q6 xor r4 xor r6 xor r7 xor rotr32(v7)
 
-  proc encrypt*(ctx: RijndaelContext, input: openarray[byte],
-                output: var openarray[byte]) =
+  proc encrypt*(ctx: RijndaelContext, input: openArray[byte],
+                output: var openArray[byte]) =
     var q: array[8, uint64]
     var w: array[4, uint32]
 
@@ -1031,8 +1031,8 @@ elif sizeof(int) == 8:
     leStore32(output, 8, w[2])
     leStore32(output, 12, w[3])
 
-  proc decrypt*(ctx: RijndaelContext, input: openarray[byte],
-                output: var openarray[byte]) =
+  proc decrypt*(ctx: RijndaelContext, input: openArray[byte],
+                output: var openArray[byte]) =
     var q: array[8, uint64]
     var w: array[16, uint32]
 
@@ -1088,7 +1088,7 @@ template sizeKey*(r: typedesc[rijndael]): int =
 template sizeBlock*(r: typedesc[rijndael]): int =
   (16)
 
-proc init*(ctx: var RijndaelContext, key: openarray[byte]) {.inline.} =
+proc init*(ctx: var RijndaelContext, key: openArray[byte]) {.inline.} =
   keySchedule(ctx, key)
 
 proc init*(ctx: var RijndaelContext, key: ptr byte, nkey: int = 0) {.inline.} =

--- a/nimcrypto/ripemd.nim
+++ b/nimcrypto/ripemd.nim
@@ -465,7 +465,7 @@ template RROUND160N5(a, b, c, d, e, x): void =
   FFF160(c, d, e, a, b, x[ 9] , 11)
   FFF160(b, c, d, e, a, x[11] , 11)
 
-proc ripemd128Transform(state: var array[4, uint32], data: openarray[byte]) =
+proc ripemd128Transform(state: var array[4, uint32], data: openArray[byte]) =
   var
     aa = state[0]
     bb = state[1]
@@ -502,7 +502,7 @@ proc ripemd128Transform(state: var array[4, uint32], data: openarray[byte]) =
   state[3] = state[0] + bb + ccc
   state[0] = ddd
 
-proc ripemd256Transform(state: var array[8, uint32], data: openarray[byte]) =
+proc ripemd256Transform(state: var array[8, uint32], data: openArray[byte]) =
   var
     aa = state[0]
     bb = state[1]
@@ -547,7 +547,7 @@ proc ripemd256Transform(state: var array[8, uint32], data: openarray[byte]) =
   state[7] = state[7] + ddd
 
 proc ripemd160Transform(state: var array[5, uint32],
-                        data: openarray[byte]) {.inline.} =
+                        data: openArray[byte]) {.inline.} =
   var
     aa = state[0]
     bb = state[1]
@@ -590,7 +590,7 @@ proc ripemd160Transform(state: var array[5, uint32],
   state[0] = ddd
 
 proc ripemd320Transform(state: var array[10, uint32],
-                        data: openarray[byte]) {.inline.} =
+                        data: openArray[byte]) {.inline.} =
   var
     aa = state[0]
     bb = state[1]
@@ -745,7 +745,7 @@ proc clear*(ctx: var RipemdContext) {.inline.} =
 proc reset*(ctx: var RipemdContext) {.inline.} =
   init(ctx)
 
-proc update*[T: bchar](ctx: var RipemdContext, data: openarray[T]) {.inline.} =
+proc update*[T: bchar](ctx: var RipemdContext, data: openArray[T]) {.inline.} =
   var pos = 0
   var length = len(data)
 
@@ -810,7 +810,7 @@ proc finalize(ctx: var RipemdContext) {.inline.} =
     ripemd320Transform(ctx.state, ctx.buffer)
 
 proc finish*(ctx: var RipemdContext,
-             data: var openarray[byte]): uint {.inline, discardable.} =
+             data: var openArray[byte]): uint {.inline, discardable.} =
   result = 0
   finalize(ctx)
   when ctx.bits == 128:

--- a/nimcrypto/sha.nim
+++ b/nimcrypto/sha.nim
@@ -78,7 +78,7 @@ proc init*(ctx: var Sha1Context) {.inline.} =
   ctx.h[4] = 0xC3D2E1F0'u32
 
 proc sha1Transform[T: bchar](ctx: var Sha1Context,
-                             blk: openarray[T],
+                             blk: openArray[T],
                              offset: int) {.noinit, inline.} =
   var
     A, B, C, D, E: uint32
@@ -195,7 +195,7 @@ proc clear*(ctx: var Sha1Context) {.inline.} =
 proc reset*(ctx: var Sha1Context) {.inline.} =
   init(ctx)
 
-proc update*[T: bchar](ctx: var Sha1Context, data: openarray[T]) {.inline.} =
+proc update*[T: bchar](ctx: var Sha1Context, data: openArray[T]) {.inline.} =
   var length = len(data)
   if length > 0:
     var lenw = int(ctx.size and 63'u64) # ctx.size mod 64
@@ -226,7 +226,7 @@ proc update*(ctx: var Sha1Context, pbytes: ptr byte,
   ctx.update(toOpenArray(p[], 0, int(nbytes) - 1))
 
 proc finish*(ctx: var Sha1Context,
-             data: var openarray[byte]): uint {.inline, discardable.} =
+             data: var openArray[byte]): uint {.inline, discardable.} =
   let
     one80 = [0x80'u8]
     one00 = [0x00'u8]

--- a/nimcrypto/sha2.nim
+++ b/nimcrypto/sha2.nim
@@ -233,7 +233,7 @@ template ROUND512(a, b, c, d, e, f, g, h, z) =
   d = d + t0
   h = t0 + t1
 
-proc sha256Transform(state: var array[8, uint32], data: openarray[byte]) =
+proc sha256Transform(state: var array[8, uint32], data: openArray[byte]) =
   var
     t0, t1: uint32
     W {.noinit.}: array[64, uint32]
@@ -336,7 +336,7 @@ proc sha256Transform(state: var array[8, uint32], data: openarray[byte]) =
   state[6] = state[6] + s6
   state[7] = state[7] + s7
 
-proc sha512Transform(state: var array[8, uint64], data: openarray[byte]) =
+proc sha512Transform(state: var array[8, uint64], data: openArray[byte]) =
   var
     t0, t1: uint64
     W {.noinit.}: array[80, uint64]
@@ -456,7 +456,7 @@ proc sha512Transform(state: var array[8, uint64], data: openarray[byte]) =
   state[6] = state[6] + s6
   state[7] = state[7] + s7
 
-proc update*[T: bchar](ctx: var Sha2Context, data: openarray[T]) {.inline.} =
+proc update*[T: bchar](ctx: var Sha2Context, data: openArray[T]) {.inline.} =
   var pos = 0
   var length = len(data)
 
@@ -522,7 +522,7 @@ proc finalize512(ctx: var Sha2Context) {.inline.} =
   sha512Transform(ctx.state, ctx.buffer)
 
 proc finish*(ctx: var Sha2Context,
-             data: var openarray[byte]): uint {.inline, discardable.} =
+             data: var openArray[byte]): uint {.inline, discardable.} =
   result = 0'u
   when ctx.bits == 224 and ctx.bsize == 64:
     if len(data) >= 28:

--- a/nimcrypto/sysrand.nim
+++ b/nimcrypto/sysrand.nim
@@ -281,7 +281,7 @@ else:
   proc randomBytes*(pbytes: pointer, nbytes: int): int =
     result = urandomRead(pbytes, nbytes)
 
-proc randomBytes*[T](bytes: var openarray[T]): int =
+proc randomBytes*[T](bytes: var openArray[T]): int =
   let length = len(bytes) * sizeof(T)
   if length > 0:
     result = randomBytes(addr bytes[0], length)

--- a/nimcrypto/twofish.nim
+++ b/nimcrypto/twofish.nim
@@ -313,8 +313,8 @@ template DEC_ROUND(CTX, R0, R1, R2, R3, round) =
   R2 = ROL(R2, 1) xor (T0 + T1 + CTX.K[2 * round + 8])
   R3 = ROR(R3 xor (T0 + 2'u32 * T1 + CTX.K[2 * round + 9]), 1)
 
-proc twofishEncrypt(ctx: var TwofishContext, inp: openarray[byte],
-                    oup: var openarray[byte]) {.inline.} =
+proc twofishEncrypt(ctx: var TwofishContext, inp: openArray[byte],
+                    oup: var openArray[byte]) {.inline.} =
   var T0, T1: uint32
 
   var r3 = ctx.K[3] xor leLoad32(inp, 12)
@@ -344,8 +344,8 @@ proc twofishEncrypt(ctx: var TwofishContext, inp: openarray[byte],
   leStore32(oup, 4, r3 xor ctx.K[5])
   leStore32(oup, 0, r2 xor ctx.K[4])
 
-proc twofishDecrypt(ctx: var TwofishContext, inp: openarray[byte],
-                    oup: var openarray[byte]) {.inline.} =
+proc twofishDecrypt(ctx: var TwofishContext, inp: openArray[byte],
+                    oup: var openArray[byte]) {.inline.} =
   var T0, T1: uint32
 
   var r3 = ctx.K[7] xor leLoad32(inp, 12)
@@ -376,7 +376,7 @@ proc twofishDecrypt(ctx: var TwofishContext, inp: openarray[byte],
   leStore32(oup, 0, r2 xor ctx.K[0])
 
 proc initTwofishContext(ctx: var TwofishContext, N: int,
-                        key: openarray[byte]) =
+                        key: openArray[byte]) =
   var
     A, B: uint32
 
@@ -421,7 +421,7 @@ template sizeKey*(r: typedesc[twofish]): int =
 template sizeBlock*(r: typedesc[twofish]): int =
   (16)
 
-proc init*(ctx: var TwofishContext, key: openarray[byte]) {.inline.} =
+proc init*(ctx: var TwofishContext, key: openArray[byte]) {.inline.} =
   initTwofishContext(ctx, ctx.bits, key)
 
 proc init*(ctx: var TwofishContext, key: ptr byte, nkey: int = 0) {.inline.} =
@@ -432,12 +432,12 @@ proc init*(ctx: var TwofishContext, key: ptr byte, nkey: int = 0) {.inline.} =
 proc clear*(ctx: var TwofishContext) {.inline.} =
   burnMem(ctx)
 
-proc encrypt*(ctx: var TwofishContext, input: openarray[byte],
-              output: var openarray[byte]) {.inline.} =
+proc encrypt*(ctx: var TwofishContext, input: openArray[byte],
+              output: var openArray[byte]) {.inline.} =
   twofishEncrypt(ctx, input, output)
 
-proc decrypt*(ctx: var TwofishContext, input: openarray[byte],
-              output: var openarray[byte]) {.inline.} =
+proc decrypt*(ctx: var TwofishContext, input: openArray[byte],
+              output: var openArray[byte]) {.inline.} =
   twofishDecrypt(ctx, input, output)
 
 proc encrypt*(ctx: var TwofishContext, inbytes: ptr byte,

--- a/nimcrypto/utils.nim
+++ b/nimcrypto/utils.nim
@@ -57,7 +57,7 @@ proc hexDigit(x: int, lowercase: bool = false): char =
     off += 0x20
   char(0x30'u32 + uint32(x) + (off and not((uint32(x) - 10) shr 8)))
 
-proc bytesToHex*(src: openarray[byte], dst: var openarray[char],
+proc bytesToHex*(src: openArray[byte], dst: var openArray[char],
                  flags: set[HexFlags]): int =
   if len(dst) == 0:
     (len(src) shl 1)
@@ -89,7 +89,7 @@ proc bytesToHex*(src: openarray[byte], dst: var openarray[char],
 
     k
 
-proc hexToBytes*(src: openarray[char], dst: var openarray[byte],
+proc hexToBytes*(src: openArray[char], dst: var openArray[byte],
                  flags: set[HexFlags]): int =
   var halfbyte = false
   var acc: byte
@@ -142,12 +142,12 @@ proc hexToBytes*(src: openarray[char], dst: var openarray[byte],
       return v
   return v
 
-proc toHex*(a: openarray[byte], flags: set[HexFlags]): string =
+proc toHex*(a: openArray[byte], flags: set[HexFlags]): string =
   var res = newString(len(a) shl 1)
   discard bytesToHex(a, res, flags)
   res
 
-proc toHex*(a: openarray[byte], lowercase: bool = false): string {.inline.} =
+proc toHex*(a: openArray[byte], lowercase: bool = false): string {.inline.} =
   var res = newString(len(a) shl 1)
   if lowercase:
     discard bytesToHex(a, res, {HexFlags.LowerCase})
@@ -155,7 +155,7 @@ proc toHex*(a: openarray[byte], lowercase: bool = false): string {.inline.} =
     discard bytesToHex(a, res, {})
   res
 
-proc hexToBytes*(a: string, output: var openarray[byte]) {.inline.} =
+proc hexToBytes*(a: string, output: var openArray[byte]) {.inline.} =
   discard hexToBytes(a, output, {HexFlags.SkipPrefix, HexFlags.PadOdd})
 
 proc fromHex*(a: string): seq[byte] =
@@ -181,7 +181,7 @@ proc burnMem*(p: pointer, size: Natural) =
       sp = cast[ptr byte](cast[uint](sp) + 1)
       dec(c)
 
-proc burnArray*[T](a: var openarray[T]) {.inline.} =
+proc burnArray*[T](a: var openArray[T]) {.inline.} =
   if len(a) > 0:
     burnMem(addr a[0], len(a) * sizeof(T))
 
@@ -207,7 +207,7 @@ proc isFullZero*(p: pointer, size: Natural): bool =
       dec(c)
   result = (counter == 0)
 
-proc isFullZero*[T](a: openarray[T]): bool {.inline.} =
+proc isFullZero*[T](a: openArray[T]): bool {.inline.} =
   result = true
   if len(a) > 0:
     result = isFullZero(unsafeAddr a[0], len(a) * sizeof(T))
@@ -327,7 +327,7 @@ template beSwap64*(a: uint64): uint64 =
   else:
     (a)
 
-template beLoad32*[T: byte|char](src: openarray[T], srco: int): uint32 =
+template beLoad32*[T: byte|char](src: openArray[T], srco: int): uint32 =
   when nimvm:
     (uint32(src[srco + 0]) shl 24) or (uint32(src[srco + 1]) shl 16) or
       (uint32(src[srco + 2]) shl 8) or uint32(src[srco + 3])
@@ -335,7 +335,7 @@ template beLoad32*[T: byte|char](src: openarray[T], srco: int): uint32 =
     let p = cast[ptr uint32](unsafeAddr src[srco])[]
     leSwap32(p)
 
-template leLoad32*[T: byte|char](src: openarray[T], srco: int): uint32 =
+template leLoad32*[T: byte|char](src: openArray[T], srco: int): uint32 =
   when nimvm:
     (uint32(src[srco + 3]) shl 24) or (uint32(src[srco + 2]) shl 16) or
       (uint32(src[srco + 1]) shl 8) or uint32(src[srco + 0])
@@ -343,7 +343,7 @@ template leLoad32*[T: byte|char](src: openarray[T], srco: int): uint32 =
     let p = cast[ptr uint32](unsafeAddr src[srco])[]
     beSwap32(p)
 
-template beLoad64*[T: byte|char](src: openarray[T], srco: int): uint64 =
+template beLoad64*[T: byte|char](src: openArray[T], srco: int): uint64 =
   when nimvm:
     (uint64(src[srco + 0]) shl 56) or (uint64(src[srco + 1]) shl 48) or
       (uint64(src[srco + 2]) shl 40) or (uint64(src[srco + 3]) shl 32) or
@@ -353,7 +353,7 @@ template beLoad64*[T: byte|char](src: openarray[T], srco: int): uint64 =
     let p = cast[ptr uint64](unsafeAddr src[srco])[]
     leSwap64(p)
 
-template leLoad64*[T: byte|char](src: openarray[T], srco: int): uint64 =
+template leLoad64*[T: byte|char](src: openArray[T], srco: int): uint64 =
   when nimvm:
     (uint64(src[srco + 7]) shl 56) or (uint64(src[srco + 6]) shl 48) or
       (uint64(src[srco + 5]) shl 40) or (uint64(src[srco + 4]) shl 32) or
@@ -363,7 +363,7 @@ template leLoad64*[T: byte|char](src: openarray[T], srco: int): uint64 =
     let p = cast[ptr uint64](unsafeAddr src[srco])[]
     beSwap64(p)
 
-template beStore32*(dst: var openarray[byte], so: int, v: uint32) =
+template beStore32*(dst: var openArray[byte], so: int, v: uint32) =
   when nimvm:
     dst[so + 0] = byte((v shr 24) and 0xFF'u32)
     dst[so + 1] = byte((v shr 16) and 0xFF'u32)
@@ -372,7 +372,7 @@ template beStore32*(dst: var openarray[byte], so: int, v: uint32) =
   else:
     cast[ptr uint32](addr dst[so])[] = leSwap32(v)
 
-template beStore64*(dst: var openarray[byte], so: int, v: uint64) =
+template beStore64*(dst: var openArray[byte], so: int, v: uint64) =
   when nimvm:
     dst[so + 0] = byte((v shr 56) and 0xFF'u64)
     dst[so + 1] = byte((v shr 48) and 0xFF'u64)
@@ -385,7 +385,7 @@ template beStore64*(dst: var openarray[byte], so: int, v: uint64) =
   else:
     cast[ptr uint64](addr dst[so])[] = leSwap64(v)
 
-template leStore32*(dst: var openarray[byte], so: int, v: uint32) =
+template leStore32*(dst: var openArray[byte], so: int, v: uint32) =
   when nimvm:
     dst[so + 0] = byte(v and 0xFF'u32)
     dst[so + 1] = byte((v shr 8) and 0xFF'u32)
@@ -394,7 +394,7 @@ template leStore32*(dst: var openarray[byte], so: int, v: uint32) =
   else:
     cast[ptr uint32](addr dst[so])[] = beSwap32(v)
 
-template leStore64*(dst: var openarray[byte], so: int, v: uint64) =
+template leStore64*(dst: var openArray[byte], so: int, v: uint64) =
   when nimvm:
     dst[so + 0] = byte(v and 0xFF'u64)
     dst[so + 1] = byte((v shr 8) and 0xFF'u64)
@@ -407,8 +407,8 @@ template leStore64*(dst: var openarray[byte], so: int, v: uint64) =
   else:
     cast[ptr uint64](addr dst[so])[] = beSwap64(v)
 
-template copyMem*[A, B](dst: var openarray[A], dsto: int,
-                        src: openarray[B], srco: int,
+template copyMem*[A, B](dst: var openArray[A], dsto: int,
+                        src: openArray[B], srco: int,
                         length: int) =
   when nimvm:
     for i in 0 ..< length:

--- a/tests/testblake2.nim
+++ b/tests/testblake2.nim
@@ -209,7 +209,7 @@ suite "BLAKE2B/BLAKE2S Tests":
         "E6C8125637438D0905B749F46560AC89FD471CF8692E28FAB982F73F019B83A9"
       ]
 
-    proc keyDigest(a: openarray[byte]): string =
+    proc keyDigest(a: openArray[byte]): string =
       var ctx: blake2_256
       ctx.init(fromHex(stripSpaces(keys[0])))
       ctx.update(a)
@@ -306,7 +306,7 @@ suite "BLAKE2B/BLAKE2S Tests":
            E2228152A3C4BBBE72FC3B12629528CFBB09FE630F0474339F54ABF453E2ED52"""
       ]
 
-    proc keyDigest(a: openarray[byte]): string =
+    proc keyDigest(a: openArray[byte]): string =
       var ctx: blake2_512
       ctx.init(fromHex(stripSpaces(keys[0])))
       ctx.update(a)

--- a/tests/testkdf.nim
+++ b/tests/testkdf.nim
@@ -470,7 +470,7 @@ suite "PBKDF2-HMAC-SHA1/SHA224/256/384/512 tests suite":
            D7"""
       ]
 
-  proc compare(x: openarray[byte], y: openarray[byte]): bool =
+  proc compare(x: openArray[byte], y: openArray[byte]): bool =
     result = false
     if len(x) == len(y):
       result = equalMem(unsafeAddr x[0], unsafeAddr y[0], len(x))

--- a/tests/testkeccak.nim
+++ b/tests/testkeccak.nim
@@ -572,7 +572,7 @@ suite "KECCAK/SHA3 Tests":
           dcheck256 == stripSpaces(sdigest256[i])
           dcheck384 == stripSpaces(sdigest384[i])
           dcheck512 == stripSpaces(sdigest512[i])
-      # openarray[T] test
+      # openArray[T] test
       check:
         $sha3_224.digest(msg) == stripSpaces(sdigest224[i])
         $sha3_256.digest(msg) == stripSpaces(sdigest256[i])


### PR DESCRIPTION
Related to https://github.com/cheatfate/nimcrypto/pull/53 but the `openArray` change only. Without it, one can't fully enable `stylecheck` elsewhere, e.g., https://github.com/status-im/nim-web3/pull/52.