### PR TITLE
align MDigest

### DIFF
--- a/nimcrypto/hash.nim
+++ b/nimcrypto/hash.nim
@@ -40,23 +40,22 @@ when MDigestAligned:
   type
     MDigest*[bits: static[int]] = object
       ## Message digest type
-      # TODO https://github.com/nim-lang/Nim/issues/22474 prevents `else` and
-      # any kind of template evaluation in when.. including >=! *sigh*
-      # The point of the below when:s is to pick one data field only while
-      # at the same time avoid alignments that would introduce postfix padding
-      when ((bits div 8) mod 16 == 0 and not ((bits div 8) < 16) and not (MDigestAlignment < 16)):
+      # We want the largest alignment such that:
+      # * the alignment evenly divides the size of the type (to avoid padding)
+      # * the alignment is not greater than the type (to avoid padding)
+      # * the alignment isn't greater than what `new` guaranteees
+      # TODO https://github.com/nim-lang/Nim/issues/22474 any kind of template
+      # evaluation in when.. including >=! *sigh*
+      when ((bits div 8) mod 16 == 0 and not ((bits div 8) < 16) and
+          not (MDigestAlignment < 16)):
         data* {.align: 16.}: array[bits div 8, byte]
-      when ((bits div 8) mod 8 == 0 and not ((bits div 8) < 8) and not (MDigestAlignment < 8)) and not (
-          ((bits div 8) mod 16 == 0 and not ((bits div 8) < 16) and not (MDigestAlignment < 16))):
+      elif ((bits div 8) mod 8 == 0 and not ((bits div 8) < 8) and
+          not (MDigestAlignment < 8)):
         data* {.align: 8.}: array[bits div 8, byte]
-      when ((bits div 8) mod 4 == 0 and not ((bits div 8) < 4) and not (MDigestAlignment < 4)) and not (
-          ((bits div 8) mod 16 == 0 and not ((bits div 8) < 16) and not (MDigestAlignment < 16)) or
-          ((bits div 8) mod 8 == 0 and not ((bits div 8) < 8) and not (MDigestAlignment < 8))):
+      elif ((bits div 8) mod 4 == 0 and not ((bits div 8) < 4) and
+          not (MDigestAlignment < 4)):
         data* {.align: 4.}: array[bits div 8, byte]
-      when not (
-          ((bits div 8) mod 16 == 0 and not ((bits div 8) < 16) and not (MDigestAlignment < 16)) or
-          ((bits div 8) mod 8 == 0 and not ((bits div 8) < 8) and not (MDigestAlignment < 8)) or
-          ((bits div 8) mod 4 == 0 and not ((bits div 8) < 4) and not (MDigestAlignment < 4))):
+      else:
         data*: array[bits div 8, byte]
 
 else:

--- a/nimcrypto/hash.nim
+++ b/nimcrypto/hash.nim
@@ -22,10 +22,8 @@ const
     ## hexadecimal output to be prefixed with ``0x``.
 
   MDigestAlignment* = when defined(nimMemAlignTiny): 4
-    elif defined(useMalloc):
-      when defined(amd64): 16
-      else: 8
-    else: 16
+    elif sizeof(int) == 8: 16
+    else: 8
     ## Aligning the digest to a reasonable boundary allows for more efficient
     ## copying and zero:ing - however, we cannot over-align the type with
     ## respect to the dynamic memory allocator or heap-based instances might
@@ -34,6 +32,9 @@ const
     ## See also:
     ## https://github.com/nim-lang/Nim/blob/v1.6.14/lib/system/bitmasks.nim#L22
     ## https://en.cppreference.com/w/cpp/types/max_align_t
+    # TODO https://github.com/nim-lang/Nim/issues/22482 (on 32-bit refc, `new`
+    #      incorrectly aligns to 8)
+
   MDigestAligned* = (NimMajor, NimMinor) >= (1, 6)
 
 when MDigestAligned:

--- a/tests/testapi.nim
+++ b/tests/testapi.nim
@@ -83,12 +83,17 @@ suite "Test API":
   when MDigestAligned:
     test "Alignment":
       proc f() =
-        var dummy: byte
-        var d: MDigest[256]
+        type Fields = object
+          dummy: byte
+          d: MDigest[256]
+        var fields: Fields
+
+        var fieldsRef = new Fields
 
         check:
-          cast[uint](addr dummy) != cast[uint](addr d) # use dummy
-          cast[uint](addr d.data[0]) mod MDigestAlignment == 0
+          cast[uint](addr fields.dummy) != cast[uint](addr fields.d) # use dummy
+          cast[uint](addr fields.d.data[0]) mod MDigestAlignment == 0
+          cast[uint](addr fieldsRef[].d.data[0]) mod MDigestAlignment == 0
 
           alignof(MDigest[32 * 8]) == min(MDigestAlignment, 32)
           alignof(MDigest[16 * 8]) == min(MDigestAlignment, 16)

--- a/tests/testapi.nim
+++ b/tests/testapi.nim
@@ -79,3 +79,28 @@ suite "Test API":
       """
     var h = keccak256.digest("")
     check $h == strip(vector)
+
+  when MDigestAligned:
+    test "Alignment":
+      proc f() =
+        var dummy: byte
+        var d: MDigest[256]
+
+        check:
+          cast[uint](addr dummy) != cast[uint](addr d) # use dummy
+          cast[uint](addr d.data[0]) mod MDigestAlignment == 0
+
+          alignof(MDigest[32 * 8]) == min(MDigestAlignment, 32)
+          alignof(MDigest[16 * 8]) == min(MDigestAlignment, 16)
+          alignof(MDigest[8 * 8]) == min(MDigestAlignment, 8)
+          alignof(MDigest[4 * 8]) == min(MDigestAlignment, 4)
+
+          sizeof(array[2, MDigest[32 * 8]]) == 2 * 32
+          sizeof(array[2, MDigest[16 * 8]]) == 2 * 16
+          sizeof(array[2, MDigest[8 * 8]]) == 2 * 8
+          sizeof(array[2, MDigest[4 * 8]]) == 2 * 4
+
+          # Alignment should not introduce array padding
+          sizeof(array[2, MDigest[7 * 8]]) == 2 * 7
+
+      f()


### PR DESCRIPTION
The introduction of alignment in MDigest allows the compiler to choose aligned instructions for copying, zeroing and processing digests resulting in better codegen for platforms with such instructions and performance increases on platforms where unaligned access is heavily penalised.

Here's an `MDigest[256]` copy without alignment:

```asm
 movdqu xmm0,XMMWORD PTR [rdi]
 movups XMMWORD PTR [rsi],xmm0
 movdqu xmm1,XMMWORD PTR [rdi+0x10]
 movups XMMWORD PTR [rsi+0x10],xmm1
```

Same, but with alignment:
```asm
 movdqa xmm0,XMMWORD PTR [rdi]
 movaps XMMWORD PTR [rsi],xmm0
 movdqa xmm1,XMMWORD PTR [rdi+0x10]
 movaps XMMWORD PTR [rsi+0x10],xmm1
```

We can see aligned loads/stores used for both (using gcc / generic x86_64 CPU) - of course, ideal alignment would be done up to 64 bytes but this breaks dynamic allocation which will not let itself be aligned further than 16 (typically).