### PR TITLE
test refc under Nim 2.0 and later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-20.04
+            builder: ubuntu-latest
           - target:
               os: macos
-            builder: macos-12
+            builder: macos-latest
           - target:
               os: windows
             builder: windows-2019

--- a/nimcrypto.nimble
+++ b/nimcrypto.nimble
@@ -14,11 +14,6 @@ requires "nim >= 1.6"
 
 let
   nimc = getEnv("NIMC", "nim") # Which nim compiler to use
-  mmopt =
-    when (NimMajor, NimMinor) >= (2, 0):
-      "--mm:orc"
-    else:
-      "--gc:orc"
 
 task test, "Runs the test suite":
   var testCommands = @[
@@ -26,15 +21,20 @@ task test, "Runs the test suite":
     nimc & " c -f -d:danger -r tests/",
     nimc & " c -f -d:danger --threads:on -r tests/",
     nimc & " c -f --passC=\"-fsanitize=undefined -fsanitize-undefined-trap-on-error\" --passL:\"-fsanitize=undefined -fsanitize-undefined-trap-on-error\" -r tests/",
-    nimc & " c -f " & mmopt & " --threads:on -r tests/"
+    nimc & " c -f --mm:orc --threads:on -r tests/"
   ]
+  when (NimMajor, NimMinor) >= (2, 0):
+    testCommands.add nimc & " c -f --mm:refc --threads:off --passC=\"-fsanitize=undefined -fsanitize-undefined-trap-on-error\" --passL:\"-fsanitize=undefined -fsanitize-undefined-trap-on-error\" -r tests/"
+    testCommands.add nimc & " c -f --mm:refc --threads:on --passC=\"-fsanitize=undefined -fsanitize-undefined-trap-on-error\" --passL:\"-fsanitize=undefined -fsanitize-undefined-trap-on-error\" -r tests/"
+    testCommands.add nimc & " c -f --mm:refc --threads:off -r tests/"
+    testCommands.add nimc & " c -f --mm:refc --threads:on -r tests/"
 
   let exampleFiles = @[
     "ecb", "cbc", "ofb", "cfb", "ctr", "gcm"
   ]
   var exampleCommands = @[
       nimc & " c -f -r --threads:on examples/",
-      nimc & " c -f " & mmopt & " --threads:on -r examples/"
+      nimc & " c -f --mm:orc --threads:on -r examples/"
   ]
 
   for cmd in testCommands:


### PR DESCRIPTION
Regarding the other changes:
- `ubuntu-latest` and `macos-latest` are evergreen, so don't need to be manually updated anymore every year or two
- because `requires "nim >= 1.6"`, it's safe to only use `-mm:foo`, even on Nim 1.6, rather than continue to include the fallback to `--gc:foo` for 1.2 and 1.4