### PR TITLE
restore generic hmac support

### DIFF
--- a/nimcrypto/sha2/sha2.nim
+++ b/nimcrypto/sha2/sha2.nim
@@ -21,7 +21,7 @@ import "."/[sha2_common, sha2_ref, sha2_avx, sha2_avx2, sha2_sha, sha2_neon]
 export hash
 export Sha2Context, Sha2Implementation, sizeDigest, sizeBlock, name,
        sha224, sha256, sha384, sha512, sha512_224, sha512_256, sha2,
-       cpufeatures, isAvailable
+       cpufeatures, isAvailable, hmacSizeBlock
 
 func reset*(ctx: var Sha2Context) {.noinit.} =
   ctx.length = 0'u64

--- a/nimcrypto/sha2/sha2_common.nim
+++ b/nimcrypto/sha2/sha2_common.nim
@@ -156,7 +156,12 @@ template sizeBlock*(r: typedesc[sha2]): int =
   else:
     (128)
 
-func name*(ctx: Sha2Context): string {.noinit.} =
+template hmacSizeBlock*(r: typedesc[sha2]): int =
+  ## Size of processing block in octets (bytes), while perform HMAC[sha2]
+  ## operation.
+  r.sizeBlock
+
+func name*(ctx: Sha2Context): string =
   when ctx is sha224:
     "SHA2-224"
   elif ctx is sha256:
@@ -172,7 +177,7 @@ func name*(ctx: Sha2Context): string {.noinit.} =
   else:
     raiseAssert "Unknown context"
 
-func name*(r: typedesc[sha2]): string {.noinit.} =
+func name*(r: typedesc[sha2]): string =
   when r is sha224:
     "SHA-224"
   elif r is sha256:

--- a/tests/testsha2.nim
+++ b/tests/testsha2.nim
@@ -1,4 +1,4 @@
-import nimcrypto/hash, nimcrypto/sha2, nimcrypto/utils
+import nimcrypto/hash, nimcrypto/sha2, nimcrypto/utils, nimcrypto/cpufeatures
 import unittest
 
 from std/strutils import toLower


### PR DESCRIPTION
Fixes a regression where hmac could no longer be used with a custom hash implementation.

* remove redundant sha2 overloads for hmac
* remove `NonOptimizedType` constraint
* evaluate `hmacSizeBlock` with mixin
* fix init type constraint
* remove `noinit` for string (unsafe)